### PR TITLE
Add support for bitcoind@0.14.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ before_script:
   - IMAGE="bitcoind:${VERSION/\//-}"
 
 env:
+  - VERSION=0.14
+  - VERSION=0.14/alpine
   - VERSION=0.13
   - VERSION=0.13/alpine
   - VERSION=0.12

--- a/0.14/Dockerfile
+++ b/0.14/Dockerfile
@@ -1,0 +1,42 @@
+FROM debian:jessie
+
+MAINTAINER Rui Marinho <rui.marinho@seegno.com> (@ruimarinho)
+
+RUN useradd -r bitcoin
+
+ENV GOSU_VERSION=1.9
+
+RUN apt-get update -y \
+  && apt-get install -y curl \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
+
+RUN curl -o /usr/local/bin/gosu -fSL https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$(dpkg --print-architecture) \
+	&& curl -o /usr/local/bin/gosu.asc -fSL https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$(dpkg --print-architecture).asc \
+	&& gpg --verify /usr/local/bin/gosu.asc \
+	&& rm /usr/local/bin/gosu.asc \
+	&& chmod +x /usr/local/bin/gosu
+
+ENV BITCOIN_VERSION=0.14.1
+ENV BITCOIN_DATA=/home/bitcoin/.bitcoin \
+  PATH=/opt/bitcoin-${BITCOIN_VERSION}/bin:$PATH
+
+RUN curl -SL https://bitcoin.org/laanwj-releases.asc | gpg --import \
+  && curl -SLO https://bitcoin.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc \
+  && curl -SLO https://bitcoin.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}${BITCOIN_BRANCH}-x86_64-linux-gnu.tar.gz \
+  && gpg --verify SHA256SUMS.asc \
+  && grep " bitcoin-${BITCOIN_VERSION}${BITCOIN_BRANCH}-x86_64-linux-gnu.tar.gz\$" SHA256SUMS.asc | sha256sum -c - \
+  && tar -xzf bitcoin-${BITCOIN_VERSION}${BITCOIN_BRANCH}-x86_64-linux-gnu.tar.gz -C /opt \
+  && rm bitcoin-${BITCOIN_VERSION}${BITCOIN_BRANCH}-x86_64-linux-gnu.tar.gz SHA256SUMS.asc
+
+VOLUME ["/home/bitcoin/.bitcoin"]
+
+COPY docker-entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+EXPOSE 8332 8333 18332 18333 18444
+
+CMD ["bitcoind"]

--- a/0.14/alpine/Dockerfile
+++ b/0.14/alpine/Dockerfile
@@ -1,0 +1,72 @@
+FROM alpine:3.4
+
+MAINTAINER Rui Marinho <rui.marinho@seegno.com> (@ruimarinho)
+
+RUN adduser -S bitcoin
+
+ENV BERKELEYDB_VERSION=db-4.8.30.NC
+ENV BERKELEYDB_PREFIX=/opt/${BERKELEYDB_VERSION}
+
+ENV BITCOIN_VERSION=0.14.1
+ENV BITCOIN_PREFIX=/opt/bitcoin-${BITCOIN_VERSION} \
+  BITCOIN_SHASUM="81a121526d5f77626a4f3d5ef2b390615e937e0aa9dc077c38c935bd7ce65d85  v${BITCOIN_VERSION}.tar.gz" \
+  BITCOIN_DATA=/home/bitcoin/.bitcoin
+ENV PATH=${BITCOIN_PREFIX}/bin:$PATH
+
+RUN apk --no-cache --virtual build-dependendencies add autoconf \
+    automake \
+    boost-dev \
+    build-base \
+    chrpath \
+    file \
+    libevent-dev \
+    openssl \
+    libtool \
+    linux-headers \
+    openssl-dev \
+    protobuf-dev \
+    zeromq-dev \
+  && mkdir -p /tmp/build \
+  && wget -O /tmp/build/${BERKELEYDB_VERSION}.tar.gz http://download.oracle.com/berkeley-db/${BERKELEYDB_VERSION}.tar.gz \
+  && tar -xzf /tmp/build/${BERKELEYDB_VERSION}.tar.gz -C /tmp/build/ \
+  && sed s/__atomic_compare_exchange/__atomic_compare_exchange_db/g -i /tmp/build/${BERKELEYDB_VERSION}/dbinc/atomic.h \
+  && mkdir -p ${BERKELEYDB_PREFIX} \
+  && cd /tmp/build/${BERKELEYDB_VERSION}/build_unix \
+  && ../dist/configure --enable-cxx --disable-shared --with-pic --prefix=${BERKELEYDB_PREFIX} \
+  && make install \
+  && wget -O /tmp/build/v${BITCOIN_VERSION}.tar.gz https://github.com/bitcoin/bitcoin/archive/v${BITCOIN_VERSION}.tar.gz \
+  && cd /tmp/build \
+  && echo "${BITCOIN_SHASUM}" | sha256sum -c \
+  && tar -xzf v${BITCOIN_VERSION}.tar.gz \
+  && cd /tmp/build/bitcoin-${BITCOIN_VERSION} \
+  && ./autogen.sh \
+  && ./configure LDFLAGS=-L${BERKELEYDB_PREFIX}/lib/ CPPFLAGS=-I${BERKELEYDB_PREFIX}/include/ \
+    --prefix=${BITCOIN_PREFIX} \
+    --mandir=/usr/share/man \
+    --disable-tests \
+    --disable-bench \
+    --disable-ccache \
+    --with-gui=no \
+    --with-utils \
+    --with-libs \
+    --with-daemon \
+  && make install \
+  && cd / \
+  && strip ${BITCOIN_PREFIX}/bin/bitcoin-cli ${BITCOIN_PREFIX}/bin/bitcoind ${BITCOIN_PREFIX}/bin/bitcoin-tx ${BITCOIN_PREFIX}/lib/libbitcoinconsensus.a ${BITCOIN_PREFIX}/lib/libbitcoinconsensus.so.0.0.0 \
+  && rm -rf /tmp/build ${BERKELEYDB_PREFIX}/docs \
+  && apk --no-cache --purge del build-dependendencies \
+  && apk --no-cache add boost \
+    boost-program_options \
+    libevent \
+    libzmq \
+    su-exec
+
+VOLUME ["/home/bitcoin/.bitcoin"]
+
+COPY docker-entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+EXPOSE 8332 8333 18332 18333 18444
+
+CMD ["bitcoind"]

--- a/0.14/alpine/docker-entrypoint.sh
+++ b/0.14/alpine/docker-entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -e
+
+if [ $(echo "$1" | cut -c1) = "-" ]; then
+  echo "$0: assuming arguments for bitcoind"
+
+  set -- bitcoind "$@"
+fi
+
+if [ $(echo "$1" | cut -c1) = "-" ] || [ "$1" = "bitcoind" ]; then
+  mkdir -p "$BITCOIN_DATA"
+  chmod 700 "$BITCOIN_DATA"
+  chown -R bitcoin "$BITCOIN_DATA"
+
+  echo "$0: setting data directory to $BITCOIN_DATA"
+
+  set -- "$@" -datadir="$BITCOIN_DATA"
+fi
+
+if [ "$1" = "bitcoind" ] || [ "$1" = "bitcoin-cli" ] || [ "$1" = "bitcoin-tx" ]; then
+  echo
+  exec su-exec bitcoin "$@"
+fi
+
+echo
+exec "$@"

--- a/0.14/docker-entrypoint.sh
+++ b/0.14/docker-entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -e
+
+if [ $(echo "$1" | cut -c1) = "-" ]; then
+  echo "$0: assuming arguments for bitcoind"
+
+  set -- bitcoind "$@"
+fi
+
+if [ $(echo "$1" | cut -c1) = "-" ] || [ "$1" = "bitcoind" ]; then
+  mkdir -p "$BITCOIN_DATA"
+  chmod 700 "$BITCOIN_DATA"
+  chown -R bitcoin "$BITCOIN_DATA"
+
+  echo "$0: setting data directory to $BITCOIN_DATA"
+
+  set -- "$@" -datadir="$BITCOIN_DATA"
+fi
+
+if [ "$1" = "bitcoind" ] || [ "$1" = "bitcoin-cli" ] || [ "$1" = "bitcoin-tx" ]; then
+  echo
+  exec gosu bitcoin "$@"
+fi
+
+echo
+exec "$@"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-2016 Seegno
+Copyright (c) 2015-2017 Seegno
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@ A bitcoind docker image.
 [![seegno/bitcoind][docker-pulls-image]][docker-hub-url] [![seegno/bitcoind][docker-stars-image]][docker-hub-url] [![seegno/bitcoind][docker-size-image]][docker-hub-url] [![seegno/bitcoind][docker-layers-image]][docker-hub-url]
 
 ## Supported tags and respective `Dockerfile` links
+- `0.14.1`, `0.14`, `latest` ([0.14/Dockerfile](https://github.com/seegno/docker-bitcoind/blob/master/0.14/Dockerfile))
+- `0.14.1-alpine`, `0.14-alpine` ([0.14/alpine/Dockerfile](https://github.com/seegno/docker-bitcoind/blob/master/0.14/alpine/Dockerfile))
 - `0.13.2-alpine`, `0.13-alpine` ([0.13/alpine/Dockerfile](https://github.com/seegno/docker-bitcoind/blob/master/0.13/alpine/Dockerfile))
-- `0.13.2`, `0.13`, `latest` ([0.13/Dockerfile](https://github.com/seegno/docker-bitcoind/blob/master/0.13/Dockerfile))
+- `0.13.2`, `0.13` ([0.13/Dockerfile](https://github.com/seegno/docker-bitcoind/blob/master/0.13/Dockerfile))
 - `0.12.1-alpine`, `0.12-alpine` ([0.12/alpine/Dockerfile](https://github.com/seegno/docker-bitcoind/blob/master/0.12/alpine/Dockerfile))
 - `0.12.1`, `0.12` ([0.12/Dockerfile](https://github.com/seegno/docker-bitcoind/blob/master/0.12/Dockerfile))
 - `0.11.2-alpine`, `0.11-alpine` ([0.11/alpine/Dockerfile](https://github.com/seegno/docker-bitcoind/blob/master/0.11/alpine/Dockerfile))
@@ -62,10 +64,10 @@ The `seegno/bitcoind` image comes in multiple flavors:
 Points to the latest release available of Bitcoin Core. Occasionally pre-release versions will be included.
 
 ### `seegno/bitcoind:<version>`
-Based on a slim Debian image, targets a specific version branch or release of Bitcoin Core (e.g. `0.13.2`, `0.13`).
+Based on a slim Debian image, targets a specific version branch or release of Bitcoin Core (e.g. `0.14.1`, `0.14`).
 
 ### `seegno/bitcoind:<version>-alpine`
-Based on Alpine Linux with Berkeley DB 4.8 (cross-compatible build), targets a specific version branch or release of Bitcoin Core (e.g. `0.13.2`, `0.13`).
+Based on Alpine Linux with Berkeley DB 4.8 (cross-compatible build), targets a specific version branch or release of Bitcoin Core (e.g. `0.14.1`, `0.14`).
 
 ## Supported Docker versions
 This image is officially supported on Docker version 1.12, with support for older versions provided on a best-effort basis.


### PR DESCRIPTION
This PR adds support for `bitcoind` version `0.14.1`.