### PR TITLE
Fix bitcoind@0.11 debian tag pin

### DIFF
--- a/0.11/Dockerfile
+++ b/0.11/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:latest
+FROM debian:jessie
 
 MAINTAINER Rui Marinho <rui.marinho@seegno.com> (@ruimarinho)
 


### PR DESCRIPTION
The tag should have pointed to `jessie` since day one. With the release of Stretch, gpg is no longer pre-shipped with the distro which made the builds fail.